### PR TITLE
Fix stale tests and run the test suite in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # python-bps (a git dependency in requirements.txt) is only needed by
+      # the patch-writing management commands, not by the test suite.
+      - run: pip install Django==5.1.7 pytest==8.3.5 numpy
+      - run: PYTHONPATH=src pytest src/tests

--- a/src/tests/animations/test_animationscripts.py
+++ b/src/tests/animations/test_animationscripts.py
@@ -339,93 +339,93 @@ test_cases = [
         expected_bytes=[0x2F, 0x00, 0x40, 0x00],
     ),
     Case(
-        label="SetAMEM8BitTo7E1x",
+        label="SetAMEM8BitToAbsolute7E",
         commands_factory=lambda: [
-            SetAMEM8BitTo7E1x(0x60, 0x7EFAC3),
+            SetAMEM8BitToAbsolute7E(0x60, 0x7EFAC3),
         ],
         expected_bytes=[0x20, 0x10, 0xC3, 0xFA],
     ),
     Case(
-        label="SetAMEM16BitTo7E1x",
+        label="SetAMEM16BitToAbsolute7E",
         commands_factory=lambda: [
-            SetAMEM16BitTo7E1x(0x60, 0x7EE022),
+            SetAMEM16BitToAbsolute7E(0x60, 0x7EE022),
         ],
         expected_bytes=[0x21, 0x10, 0x22, 0xE0],
     ),
     Case(
-        label="Set7E1xToAMEM8Bit",
+        label="SetAbsolute7EToAMEM8Bit",
         commands_factory=lambda: [
-            Set7E1xToAMEM8Bit(0x7EE001, 0x60),
+            SetAbsolute7EToAMEM8Bit(0x7EE001, 0x60),
         ],
         expected_bytes=[0x22, 0x10, 0x01, 0xE0],
     ),
     Case(
-        label="Set7E1xToAMEM16Bit",
+        label="SetAbsolute7EToAMEM16Bit",
         commands_factory=lambda: [
-            Set7E1xToAMEM16Bit(0x7EE022, 0x60),
+            SetAbsolute7EToAMEM16Bit(0x7EE022, 0x60),
         ],
         expected_bytes=[0x23, 0x10, 0x22, 0xE0],
     ),
     Case(
-        label="JmpIfAMEM8BitEquals7E1x",
+        label="JmpIfAMEM8BitEqualsAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM8BitEquals7E1x(0x61, 0x7EE003, ["jmp"]),
+            JmpIfAMEM8BitEqualsAbsolute7E(0x61, 0x7EE003, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x24, 0x11, 0x03, 0xE0, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM16BitEquals7E1x",
+        label="JmpIfAMEM16BitEqualsAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM16BitEquals7E1x(0x61, 0x7EE005, ["jmp"]),
+            JmpIfAMEM16BitEqualsAbsolute7E(0x61, 0x7EE005, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x25, 0x11, 0x05, 0xE0, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM8BitNotEquals7E1x",
+        label="JmpIfAMEM8BitNotEqualsAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM8BitNotEquals7E1x(0x60, 0x7EFA00, ["jmp"]),
+            JmpIfAMEM8BitNotEqualsAbsolute7E(0x60, 0x7EFA00, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x26, 0x10, 0x00, 0xFA, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM16BitNotEquals7E1x",
+        label="JmpIfAMEM16BitNotEqualsAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM16BitNotEquals7E1x(0x62, 0x7EFA00, ["jmp"]),
+            JmpIfAMEM16BitNotEqualsAbsolute7E(0x62, 0x7EFA00, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x27, 0x12, 0x00, 0xFA, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM8BitLessThan7E1x",
+        label="JmpIfAMEM8BitLessThanAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM8BitLessThan7E1x(0x63, 0x7E0F00, ["jmp"]),
+            JmpIfAMEM8BitLessThanAbsolute7E(0x63, 0x7E0F00, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x28, 0x13, 0x00, 0x0F, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM16BitLessThan7E1x",
+        label="JmpIfAMEM16BitLessThanAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM16BitLessThan7E1x(0x61, 0x7EE100, ["jmp"]),
+            JmpIfAMEM16BitLessThanAbsolute7E(0x61, 0x7EE100, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x29, 0x11, 0x00, 0xE1, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM8BitGreaterOrEqualThan7E1x",
+        label="JmpIfAMEM8BitGreaterOrEqualThanAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM8BitGreaterOrEqualThan7E1x(0x60, 0x7E1000, ["jmp"]),
+            JmpIfAMEM8BitGreaterOrEqualThanAbsolute7E(0x60, 0x7E1000, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[0x2A, 0x10, 0x00, 0x10, 0x08, 0xC0, 0x11],
     ),
     Case(
-        label="JmpIfAMEM16BitGreaterOrEqualThan7E1x",
+        label="JmpIfAMEM16BitGreaterOrEqualThanAbsolute7E",
         commands_factory=lambda: [
-            JmpIfAMEM16BitGreaterOrEqualThan7E1x(0x65, 0x7E0200, ["jmp"]),
+            JmpIfAMEM16BitGreaterOrEqualThanAbsolute7E(0x65, 0x7E0200, ["jmp"]),
             ReturnSubroutine(identifier="jmp"),
         ],
         expected_bytes=[
@@ -439,23 +439,23 @@ test_cases = [
         ],
     ),
     Case(
-        label="IncAMEM8BitBy7E1x",
-        commands_factory=lambda: [IncAMEM8BitBy7E1x(0x67, 0x7E3100)],
+        label="IncAMEM8BitByAbsolute7E",
+        commands_factory=lambda: [IncAMEM8BitByAbsolute7E(0x67, 0x7E3100)],
         expected_bytes=[0x2C, 0x17, 0x00, 0x31],
     ),
     Case(
-        label="IncAMEM16BitBy7E1x",
-        commands_factory=lambda: [IncAMEM16BitBy7E1x(0x66, 0x7E1000)],
+        label="IncAMEM16BitByAbsolute7E",
+        commands_factory=lambda: [IncAMEM16BitByAbsolute7E(0x66, 0x7E1000)],
         expected_bytes=[0x2D, 0x16, 0x00, 0x10],
     ),
     Case(
-        label="DecAMEM8BitBy7E1x",
-        commands_factory=lambda: [DecAMEM8BitBy7E1x(0x61, 0x7EA000)],
+        label="DecAMEM8BitByAbsolute7E",
+        commands_factory=lambda: [DecAMEM8BitByAbsolute7E(0x61, 0x7EA000)],
         expected_bytes=[0x2E, 0x11, 0x00, 0xA0],
     ),
     Case(
-        label="DecAMEM16BitBy7E1x",
-        commands_factory=lambda: [DecAMEM16BitBy7E1x(0x64, 0x7E0F00)],
+        label="DecAMEM16BitByAbsolute7E",
+        commands_factory=lambda: [DecAMEM16BitByAbsolute7E(0x64, 0x7E0F00)],
         expected_bytes=[0x2F, 0x14, 0x00, 0x0F],
     ),
     Case(

--- a/src/tests/dialogs/test_formatter.py
+++ b/src/tests/dialogs/test_formatter.py
@@ -127,10 +127,11 @@ class TestTokenize:
         assert tokens[0].is_variable
         assert tokens[0].width_px == 16  # 2 * (7+1)
 
-    def test_long_variable_token(self):
+    def test_filename_token(self):
         tokens = _tokenize("[filename]")
         assert len(tokens) == 1
-        assert tokens[0].is_long_variable
+        assert tokens[0].is_variable
+        assert tokens[0].width_px == 80  # 8 chars * widest letter width
 
     def test_mixed_text(self):
         tokens = _tokenize("Hello world[await]\n")

--- a/src/tests/monsters/test_ai.py
+++ b/src/tests/monsters/test_ai.py
@@ -2,7 +2,7 @@ import pytest
 
 from dataclasses import dataclass
 
-from disassembler_output.spells.spells import CharacterSpell, EnemySpell
+from smrpgpatchbuilder.datatypes.spells.classes import CharacterSpell, EnemySpell
 from smrpgpatchbuilder.datatypes.enemy_attacks.classes import EnemyAttack
 from smrpgpatchbuilder.datatypes.items.classes import RegularItem
 from smrpgpatchbuilder.datatypes.monster_scripts import *

--- a/src/tests/overworld/test_actionscripts.py
+++ b/src/tests/overworld/test_actionscripts.py
@@ -1854,14 +1854,14 @@ test_cases = [
     Case(
         "Valid unknown command",
         commands_factory=lambda: [
-            A_UnknownCommand(bytearray([0x24, 0xAB, 0xCD, 0xFE, 0x69])),
+            A_UnknownCommand(bytearray([0x25, 0xAB, 0xCD, 0xFE, 0x69])),
         ],
-        expected_bytes=[0x24, 0xAB, 0xCD, 0xFE, 0x69],
+        expected_bytes=[0x25, 0xAB, 0xCD, 0xFE, 0x69],
     ),
     Case(
         "Unknown command with wrong length should fail",
-        commands_factory=lambda: [A_UnknownCommand(bytearray([0x24, 0xAB, 0xCD]))],
-        exception="opcode 0x24 expects 5 total bytes (inclusive), got 3 bytes instead",
+        commands_factory=lambda: [A_UnknownCommand(bytearray([0x25, 0xAB, 0xCD]))],
+        exception="opcode 0x25 expects 5 total bytes (inclusive), got 3 bytes instead",
         exception_type=InvalidCommandArgumentException,
     ),
     Case(


### PR DESCRIPTION
On a fresh clone, `PYTHONPATH=src pytest src/tests` currently can't run at all — one collection error aborts the whole suite — and behind that sit 19 failures. All of them turned out to be tests that went stale against intentional library changes, not library bugs. This PR fixes them and adds a GitHub Actions workflow so the suite runs on every push and PR.

## Test fixes

- **`test_ai.py` blocked the entire suite.** It imported `CharacterSpell`/`EnemySpell` from the generated `disassembler_output.spells.spells`, which only exists after running `spelldisassembler` against a ROM, and pytest aborts collection on the resulting `ModuleNotFoundError`. Those two names are library base classes, so the test now imports them from `smrpgpatchbuilder.datatypes.spells.classes` directly — its 54 tests run (and pass) with no ROM.
- **`test_animationscripts.py` (16 failures):** still referenced the `*7E1x` command names from before they were renamed to `*Absolute7E`. Renamed; all byte-level expectations pass unchanged.
- **`test_actionscripts.py` (2 failures):** the `A_UnknownCommand` cases used opcode `0x24`, which is now handled by `A_SetSubroutineXTargets` and therefore correctly rejected. Switched to `0x25`, which is still unassigned with the same 5-byte expected length, preserving the tests' intent.
- **`test_formatter.py` (1 failure):** `test_long_variable_token` asserted the retired `_LONG_TOKENS` force-a-line-break behaviour for `[filename]`; since that design was replaced, `[filename]` is an ordinary variable token with a fixed 80px width. The test now asserts the current behaviour.

## CI

`.github/workflows/tests.yml` runs the suite on Ubuntu with Python 3.12 on pushes and pull requests. It installs only what the tests need (`Django`, `pytest`, `numpy`) — the `python-bps` git dependency in requirements.txt is only used by the patch-writing management commands, so CI skips it to avoid depending on GitLab availability.

## Result

Before: collection error + 19 failures. After: **852 passed, 0 failed**, no ROM required. No library code is touched by this PR; it's independent of #4 and they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)