### PR TITLE
Exclude tests from built wheels via explicit package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,9 @@ dependencies=[
 Homepage = "https://github.com/pidgezero-one/smrpgpatchbuilder"
 Issues = "https://github.com/pidgezero-one/smrpgpatchbuilder/issues"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["smrpgpatchbuilder*"]
+
 [tool.pytest.ini_options]
 addopts = "-v -s"


### PR DESCRIPTION
Limits setuptools package discovery to `smrpgpatchbuilder*`, so built wheels no longer ship a top-level `tests` package (wheel contents otherwise identical to 7.1.7, verified by diffing file lists).